### PR TITLE
update socket2 & other deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unix-udp-sock"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/leshow/unix-udp-sock"
@@ -10,15 +10,15 @@ categories = ["network-programming", "asynchronous"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.126"
-socket2 = "0.4"
-tracing = "0.1.35"
-tokio = { version = "1.19", features = ["net"] }
-tokio-util = { version = "0.7.0", features = [ "codec", "net" ] }
+libc = "0.2.153"
+socket2 = "0.5.6"
+tracing = "0.1.40"
+tokio = { version = "1.37.0", features = ["net"] }
+tokio-util = { version = "0.7.10", features = ["codec", "net"] }
 bytes = "1.1.0"
-futures-core = "0.3.0"
-futures-sink = "0.3.0"
-pin-project-lite = "0.2.0"
+futures-core = "0.3.30"
+futures-sink = "0.3.30"
+pin-project-lite = "0.2.14"
 
 # [dev-dependencies]
 # nix = "0.26"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::unnecessary_cast)]
 use std::{
-    io,
-    io::IoSliceMut,
+    io::{self, IoSliceMut},
     mem::{self, MaybeUninit},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
-    os::unix::io::AsRawFd,
+    os::{fd::AsFd, unix::io::AsRawFd},
     sync::atomic::AtomicUsize,
     task::{Context, Poll},
     time::Instant,
@@ -38,6 +37,12 @@ pub struct UdpSocket {
 impl AsRawFd for UdpSocket {
     fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
         self.io.as_raw_fd()
+    }
+}
+
+impl AsFd for UdpSocket {
+    fn as_fd(&self) -> std::os::unix::prelude::BorrowedFd<'_> {
+        self.io.as_fd()
     }
 }
 


### PR DESCRIPTION
socket2 uses `AsFd` to convert to SockRef now, rather than `AsRawFd`