### PR TITLE
Register SO_ERROR

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: --all-features -- --nocapture
 
   test-mac:
     name: Test Suite (macOS)
@@ -97,7 +97,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: --all-features -- --nocapture
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 libc = "0.2.153"
-socket2 = "0.5.6"
+socket2 = "0.6.3"
 tracing = "0.1.40"
-tokio = { version = "1.37.0", features = ["net"] }
-tokio-util = { version = "0.7.10", features = ["codec", "net"] }
-bytes = "1.1.0"
+tokio = { version = "1.51.0", features = ["net"] }
+tokio-util = { version = "0.7.18", features = ["codec", "net"] }
+bytes = "1.11.1"
 futures-core = "0.3.30"
 futures-sink = "0.3.30"
 pin-project-lite = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ categories = ["network-programming", "asynchronous"]
 libc = "0.2.153"
 socket2 = "0.6.3"
 tracing = "0.1.40"
-tokio = { version = "1.51.0", features = ["net"] }
+tokio = { version = "1.50.0", features = ["net"] }
 tokio-util = { version = "0.7.18", features = ["codec", "net"] }
 bytes = "1.11.1"
 futures-core = "0.3.30"
 futures-sink = "0.3.30"
 pin-project-lite = "0.2.14"
 
-# [dev-dependencies]
+[dev-dependencies]
+tokio = { version = "1.50.0", features = ["macros", "rt"] }
 # nix = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ futures-sink = "0.3.30"
 pin-project-lite = "0.2.14"
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["macros", "rt"] }
+tokio = { version = "1.50.0", features = ["macros", "rt", "time"] }
 # nix = "0.26"

--- a/src/cmsg.rs
+++ b/src/cmsg.rs
@@ -39,7 +39,7 @@ impl<'a> Encoder<'a> {
     /// - If insufficient buffer space remains.
     /// - If `T` has stricter alignment requirements than `cmsghdr`
     #[allow(clippy::unnecessary_cast)]
-    pub fn push<T: Copy + ?Sized>(&mut self, level: libc::c_int, ty: libc::c_int, value: T) {
+    pub fn push<T: Copy>(&mut self, level: libc::c_int, ty: libc::c_int, value: T) {
         assert!(mem::align_of::<T>() <= mem::align_of::<libc::cmsghdr>());
         let space = unsafe { libc::CMSG_SPACE(mem::size_of_val(&value) as _) as usize };
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ mod tests {
     }
 
     // from: https://github.com/tokio-rs/tokio/issues/8000
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_so_error() {
         // Bind a server socket then immediately drop it to get a port we know is closed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ fn log_sendmsg_error<B: AsPtr<u8>>(
 
 #[cfg(test)]
 mod tests {
-    use std::{future::poll_fn, io::IoSliceMut, net::Ipv4Addr, time::Duration};
+    use std::net::Ipv4Addr;
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,13 @@ pub struct RecvMeta {
     pub ecn: Option<EcnCodepoint>,
     /// The destination IP address for this datagram (ipi_addr)
     pub dst_ip: Option<IpAddr>,
-    /// The destination local IP address for this datagram (ipi_spec_dst)
+    /// The destination local IP address for this datagram
+    ///
+    /// On Linux IPv4 this corresponds to `ipi_spec_dst` and can differ from
+    /// `dst_ip`.
+    ///
+    /// On macOS and FreeBSD IPv4 this is derived from `IP_RECVDSTADDR`, so it
+    /// may be identical to `dst_ip`.
     pub dst_local_ip: Option<IpAddr>,
     /// interface index that datagram was received on
     pub ifindex: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,21 +129,21 @@ mod tests {
 
     #[test]
     fn test_create() {
-        let s = sync::UdpSocket::bind("0.0.0.0:9909");
+        let s = sync::UdpSocket::bind("127.0.0.1:9909");
         assert!(s.is_ok());
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_create_async() {
-        let s = UdpSocket::bind("0.0.0.0:0").await;
+        let s = UdpSocket::bind("127.0.0.1:0").await;
         assert!(s.is_ok());
     }
 
     #[test]
     fn test_send_recv() {
-        let saddr = "0.0.0.0:9901".parse().unwrap();
+        let saddr = "127.0.0.1:9901".parse().unwrap();
         let a = sync::UdpSocket::bind(saddr).unwrap();
-        let b = sync::UdpSocket::bind("0.0.0.0:0").unwrap();
+        let b = sync::UdpSocket::bind("127.0.0.1:0").unwrap();
         let buf = b"hello world";
         b.send_to(&buf[..], saddr).unwrap();
         // recv
@@ -154,9 +154,9 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_send_recv_async() {
-        let a = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let saddr = a.local_addr().unwrap();
-        let b = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let buf = b"hello world";
         b.send_to(&buf[..], saddr).await.unwrap();
 
@@ -167,9 +167,9 @@ mod tests {
 
     #[test]
     fn test_send_recv_msg() {
-        let saddr = "0.0.0.0:9902".parse().unwrap();
+        let saddr = "127.0.0.1:9902".parse().unwrap();
         let a = sync::UdpSocket::bind(saddr).unwrap();
-        let b = sync::UdpSocket::bind("0.0.0.0:0").unwrap();
+        let b = sync::UdpSocket::bind("127.0.0.1:0").unwrap();
         let send_port = b.local_addr().unwrap().port();
         let send_addr = b.local_addr().unwrap().ip();
         let buf = b"hello world";
@@ -193,9 +193,9 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_send_recv_msg_async() {
-        let a = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let saddr = a.local_addr().unwrap();
-        let b = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let send_port = b.local_addr().unwrap().port();
         let send_addr = b.local_addr().unwrap().ip();
         let buf = b"hello world";
@@ -217,13 +217,13 @@ mod tests {
 
     #[test]
     fn test_send_recv_msg_ip() {
-        let saddr = "0.0.0.0:9903".parse().unwrap();
+        let saddr = "127.0.0.1:9903".parse().unwrap();
         let a = sync::UdpSocket::bind(saddr).unwrap();
-        let b = sync::UdpSocket::bind("0.0.0.0:0").unwrap();
+        let b = sync::UdpSocket::bind("127.0.0.1:0").unwrap();
         let send_port = b.local_addr().unwrap().port();
         let send_addr = b.local_addr().unwrap().ip();
         let buf = b"hello world";
-        let src = Source::Ip("0.0.0.0".parse().unwrap());
+        let src = Source::Ip("127.0.0.1".parse().unwrap());
         let tr = Transmit::new(saddr, *buf).src_ip(src);
         b.send_msg(&UdpState::new(), tr).unwrap();
         // recv
@@ -243,13 +243,13 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_send_recv_msg_ip_async() {
-        let a = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let saddr = a.local_addr().unwrap();
-        let b = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let send_port = b.local_addr().unwrap().port();
         let send_addr = b.local_addr().unwrap().ip();
         let buf = b"hello world";
-        let src = Source::Ip("0.0.0.0".parse().unwrap());
+        let src = Source::Ip("127.0.0.1".parse().unwrap());
         let tr = Transmit::new(saddr, *buf).src_ip(src);
         b.send_msg(&UdpState::new(), tr).await.unwrap();
 
@@ -276,7 +276,7 @@ mod tests {
         let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         sock.connect(target).await.unwrap();
         let buf = b"hello world";
-        let src = Source::Ip("0.0.0.0".parse().unwrap());
+        let src = Source::Ip("127.0.0.1".parse().unwrap());
         let tr = Transmit::new(target, *buf).src_ip(src);
         sock.send_msg(&UdpState::new(), tr).await.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ fn log_sendmsg_error<B: AsPtr<u8>>(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::{future::poll_fn, io::IoSliceMut, net::Ipv4Addr, time::Duration};
 
     use super::*;
 
@@ -281,8 +281,30 @@ mod tests {
         sock.send_msg(&UdpState::new(), tr).await.unwrap();
 
         let mut buf = [0; 11];
-        let result = sock.recv_msg(&mut buf).await; // hangs infinitely if so_error isn't registered
-        dbg!(&result);
-        assert!(result.is_err());
+        let result = sock.recv_msg(&mut buf).await.unwrap_err(); // hangs infinitely if so_error isn't registered
+        assert_eq!(result.kind(), std::io::ErrorKind::ConnectionRefused);
     }
+
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_poll_recv_msg_so_error() {
+    //     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    //     let target: SocketAddr = server.local_addr().unwrap();
+    //     drop(server);
+
+    //     let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    //     sock.connect(target).await.unwrap();
+    //     sock.send(b"ping").await.unwrap();
+
+    //     let mut buf = [0; 8];
+    //     let mut iov = IoSliceMut::new(&mut buf);
+    //     let result = tokio::time::timeout(
+    //         Duration::from_millis(200),
+    //         poll_fn(|cx| sock.poll_recv_msg(cx, &mut iov)),
+    //     )
+    //     .await
+    //     .expect("poll_recv_msg timed out before returning the socket error")
+    //     .unwrap_err();
+
+    //     assert_eq!(result.kind(), std::io::ErrorKind::ConnectionRefused);
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,13 @@ mod tests {
         let s = sync::UdpSocket::bind("0.0.0.0:9909");
         assert!(s.is_ok());
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_create_async() {
+        let s = UdpSocket::bind("0.0.0.0:0").await;
+        assert!(s.is_ok());
+    }
+
     #[test]
     fn test_send_recv() {
         let saddr = "0.0.0.0:9901".parse().unwrap();
@@ -144,6 +151,20 @@ mod tests {
         a.recv_from(&mut r).unwrap();
         assert_eq!(buf[..], r[..11]);
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_send_recv_async() {
+        let a = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let saddr = a.local_addr().unwrap();
+        let b = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let buf = b"hello world";
+        b.send_to(&buf[..], saddr).await.unwrap();
+
+        let mut r = [0; 1024];
+        a.recv_from(&mut r).await.unwrap();
+        assert_eq!(buf[..], r[..11]);
+    }
+
     #[test]
     fn test_send_recv_msg() {
         let saddr = "0.0.0.0:9902".parse().unwrap();
@@ -169,6 +190,31 @@ mod tests {
             Some(addr) if addr == send_addr || addr == IpAddr::V4(Ipv4Addr::LOCALHOST)
         ));
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_send_recv_msg_async() {
+        let a = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let saddr = a.local_addr().unwrap();
+        let b = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let send_port = b.local_addr().unwrap().port();
+        let send_addr = b.local_addr().unwrap().ip();
+        let buf = b"hello world";
+        let src = Source::Interface(1);
+        let tr = Transmit::new(saddr, *buf).src_ip(src);
+        b.send_msg(&UdpState::new(), tr).await.unwrap();
+
+        let mut r = [0; 1024];
+        let meta = a.recv_msg(&mut r).await.unwrap();
+        assert_eq!(buf[..], r[..11]);
+        assert_eq!(send_port, meta.addr.port());
+        assert_eq!(meta.ifindex, 1);
+        assert!(matches!(
+            meta.dst_local_ip,
+            // dst_local_ip might be 127.0.0.1
+            Some(addr) if addr == send_addr || addr == IpAddr::V4(Ipv4Addr::LOCALHOST)
+        ));
+    }
+
     #[test]
     fn test_send_recv_msg_ip() {
         let saddr = "0.0.0.0:9903".parse().unwrap();
@@ -193,5 +239,50 @@ mod tests {
             // dst_local_ip might be 127.0.0.1
             Some(addr) if addr == send_addr || addr == IpAddr::V4(Ipv4Addr::LOCALHOST)
         ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_send_recv_msg_ip_async() {
+        let a = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let saddr = a.local_addr().unwrap();
+        let b = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let send_port = b.local_addr().unwrap().port();
+        let send_addr = b.local_addr().unwrap().ip();
+        let buf = b"hello world";
+        let src = Source::Ip("0.0.0.0".parse().unwrap());
+        let tr = Transmit::new(saddr, *buf).src_ip(src);
+        b.send_msg(&UdpState::new(), tr).await.unwrap();
+
+        let mut r = [0; 1024];
+        let meta = a.recv_msg(&mut r).await.unwrap();
+        assert_eq!(buf[..], r[..11]);
+        assert_eq!(send_port, meta.addr.port());
+        assert_eq!(meta.ifindex, 1);
+        assert!(matches!(
+            meta.dst_local_ip,
+            // dst_local_ip might be 127.0.0.1
+            Some(addr) if addr == send_addr || addr == IpAddr::V4(Ipv4Addr::LOCALHOST)
+        ));
+    }
+
+    // from: https://github.com/tokio-rs/tokio/issues/8000
+    #[tokio::test]
+    async fn test_so_error() {
+        // Bind a server socket then immediately drop it to get a port we know is closed
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let target: SocketAddr = server.local_addr().unwrap();
+        drop(server);
+
+        let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sock.connect(target).await.unwrap();
+        let buf = b"hello world";
+        let src = Source::Ip("0.0.0.0".parse().unwrap());
+        let tr = Transmit::new(target, *buf).src_ip(src);
+        sock.send_msg(&UdpState::new(), tr).await.unwrap();
+
+        let mut buf = [0; 11];
+        let result = sock.recv_msg(&mut buf).await; // hangs infinitely if so_error isn't registered
+        dbg!(&result);
+        assert!(result.is_err());
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -739,13 +739,7 @@ fn init(io: SockRef<'_>) -> io::Result<()> {
             )?;
         }
     }
-    #[cfg(target_os = "macos")]
-    {
-        if is_ipv4 {
-            set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_PKTINFO, OPTION_ON)?;
-        }
-    }
-    #[cfg(target_os = "freebsd")]
+    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
     // IP_RECVDSTADDR == IP_SENDSRCADDR on FreeBSD
     // macOS uses only IP_RECVDSTADDR, no IP_SENDSRCADDR on macOS
     // macOS also supports IP_PKTINFO
@@ -1276,7 +1270,7 @@ fn decode_recv(
                     ecn_bits = cmsg::decode::<libc::c_int>(cmsg) as u8;
                 }
             },
-            #[cfg(not(target_os = "freebsd"))]
+            #[cfg(target_os = "linux")]
             (libc::IPPROTO_IP, libc::IP_PKTINFO) => {
                 let pktinfo = unsafe { cmsg::decode::<libc::in_pktinfo>(cmsg) };
                 dst_ip = Some(IpAddr::V4(Ipv4Addr::from(
@@ -1287,13 +1281,19 @@ fn decode_recv(
                 )));
                 ifindex = pktinfo.ipi_ifindex as _;
             }
+            #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+            (libc::IPPROTO_IP, libc::IP_RECVDSTADDR) => {
+                let in_addr = unsafe { cmsg::decode::<libc::in_addr>(cmsg) };
+                let addr = IpAddr::V4(Ipv4Addr::from(in_addr.s_addr.to_ne_bytes()));
+                dst_ip = Some(addr);
+                dst_local_ip = Some(addr);
+            }
             (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
                 let pktinfo = unsafe { cmsg::decode::<libc::in6_pktinfo>(cmsg) };
                 dst_ip = Some(IpAddr::V6(Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr)));
                 ifindex = pktinfo.ipi6_ifindex;
             }
-            // freebsd doesn't have PKTINFO
-            #[cfg(target_os = "freebsd")]
+            #[cfg(any(target_os = "freebsd", target_os = "macos"))]
             (libc::IPPROTO_IP, libc::IP_RECVIF) => {
                 let info = unsafe { cmsg::decode::<libc::sockaddr_dl>(cmsg) };
                 ifindex = info.sdl_index as _;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -421,9 +421,7 @@ impl UdpSocket {
         loop {
             ready!(self.io.poll_recv_ready(cx))?;
             let io = &self.io;
-            if let Ok(res) = io.try_io(Interest::READABLE | Interest::ERROR, || {
-                recv_msg(SockRef::from(io), buf)
-            }) {
+            if let Ok(res) = io.try_io(Interest::READABLE, || recv_msg(SockRef::from(io), buf)) {
                 return Poll::Ready(Ok(res));
             }
         }
@@ -450,7 +448,7 @@ impl UdpSocket {
         loop {
             ready!(self.io.poll_recv_ready(cx))?;
             let io = &self.io;
-            if let Ok(res) = io.try_io(Interest::READABLE | Interest::ERROR, || {
+            if let Ok(res) = io.try_io(Interest::READABLE, || {
                 recv::<BATCH_SIZE>(SockRef::from(io), bufs, meta)
             }) {
                 return Poll::Ready(Ok(res));

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -216,7 +216,7 @@ impl UdpSocket {
     /// See tokio [`poll_send`]
     ///
     /// [`poll_send`]: method@tokio::net::UdpSocket::poll_send
-    pub async fn poll_send(&self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+    pub fn poll_send(&self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         self.io.poll_send(cx, buf)
     }
     /// Receives a single datagram message on the socket. On success, returns

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -293,17 +293,14 @@ impl UdpSocket {
         state: &UdpState,
         transmits: &[Transmit<B>],
     ) -> Result<usize, io::Error> {
-        let n = loop {
-            self.io.writable().await?;
-            let last_send_error = self.last_send_error.clone();
-            let io = &self.io;
-            match io.try_io(Interest::WRITABLE, || {
+        let io = &self.io;
+        let n = io
+            .async_io(Interest::WRITABLE, move || {
+                let last_send_error = self.last_send_error.clone();
                 send::<_, BATCH_SIZE>(state, SockRef::from(io), last_send_error, transmits)
-            }) {
-                Ok(res) => break res,
-                Err(_would_block) => continue,
-            }
-        };
+            })
+            .await?;
+
         // if n == transmits.len() {}
         Ok(n)
     }
@@ -317,16 +314,13 @@ impl UdpSocket {
         state: &UdpState,
         transmits: Transmit<B>,
     ) -> io::Result<usize> {
-        let n = loop {
-            self.io.writable().await?;
-            let io = &self.io;
-            match io.try_io(Interest::WRITABLE, || {
+        let io = &self.io;
+        let n = io
+            .async_io(Interest::WRITABLE, move || {
                 send_msg(state, SockRef::from(io), &transmits)
-            }) {
-                Ok(res) => break res,
-                Err(_would_block) => continue,
-            }
-        };
+            })
+            .await?;
+
         Ok(n)
     }
 
@@ -346,16 +340,11 @@ impl UdpSocket {
         meta: &mut [RecvMeta],
     ) -> io::Result<usize> {
         debug_assert!(!bufs.is_empty());
-        loop {
-            self.io.readable().await?;
-            let io = &self.io;
-            match io.try_io(Interest::READABLE, || {
-                recv::<BATCH_SIZE>(SockRef::from(io), bufs, meta)
-            }) {
-                Ok(res) => return Ok(res),
-                Err(_would_block) => continue,
-            }
-        }
+        let io = &self.io;
+        io.async_io(Interest::READABLE | Interest::ERROR, || {
+            recv::<BATCH_SIZE>(SockRef::from(io), bufs, meta)
+        })
+        .await
     }
 
     /// `recv_msg` is similar to `recv_from` but returns extra information
@@ -365,14 +354,11 @@ impl UdpSocket {
     pub async fn recv_msg(&self, buf: &mut [u8]) -> io::Result<RecvMeta> {
         let mut iov = IoSliceMut::new(buf);
         debug_assert!(!iov.is_empty());
-        loop {
-            self.io.readable().await?;
-            let io = &self.io;
-            match io.try_io(Interest::READABLE, || recv_msg(SockRef::from(io), &mut iov)) {
-                Ok(res) => return Ok(res),
-                Err(_would_block) => continue,
-            }
-        }
+        let io = &self.io;
+        io.async_io(Interest::READABLE | Interest::ERROR, || {
+            recv_msg(SockRef::from(io), &mut iov)
+        })
+        .await
     }
 
     /// calls `sendmmsg`
@@ -435,7 +421,9 @@ impl UdpSocket {
         loop {
             ready!(self.io.poll_recv_ready(cx))?;
             let io = &self.io;
-            if let Ok(res) = io.try_io(Interest::READABLE, || recv_msg(SockRef::from(io), buf)) {
+            if let Ok(res) = io.try_io(Interest::READABLE | Interest::ERROR, || {
+                recv_msg(SockRef::from(io), buf)
+            }) {
                 return Poll::Ready(Ok(res));
             }
         }
@@ -462,7 +450,7 @@ impl UdpSocket {
         loop {
             ready!(self.io.poll_recv_ready(cx))?;
             let io = &self.io;
-            if let Ok(res) = io.try_io(Interest::READABLE, || {
+            if let Ok(res) = io.try_io(Interest::READABLE | Interest::ERROR, || {
                 recv::<BATCH_SIZE>(SockRef::from(io), bufs, meta)
             }) {
                 return Poll::Ready(Ok(res));


### PR DESCRIPTION
https://github.com/tokio-rs/tokio/pull/8001

must register ERROR to get SO_ERROR. Also noticed that some spots use try_io in a loop when this can be replaced with `async_io` which is now public.